### PR TITLE
Add PG_USER and PG_PASSWORD to heroku README.md

### DIFF
--- a/template/$PROJECT_NAME$/README.md
+++ b/template/$PROJECT_NAME$/README.md
@@ -107,10 +107,9 @@ contains the JWT in the "Bearer" realm of the authorization header.
 ```
 <%= if @is_heroku? do %>
 * DATABASE_URL - The URL to your postgres database instance on Heroku
-<% else %>
+<% end %>
 * PG_USER - The postgres username
 * PG_PASSWORD - THe postgres password
-<% end %>
 
 ### JWT Key Configuration
 


### PR DESCRIPTION
Add the PG_USER and PG_PASSWORD mentions back to the generated README
when using the heroku flag, as these are still environment variables
that need to be set when working in the development and test
environments